### PR TITLE
Fix typo in query docs

### DIFF
--- a/content/en/docs/query/index.md
+++ b/content/en/docs/query/index.md
@@ -34,7 +34,7 @@ for details.
 Let's take a look at a query that shows the main elements.
 
 ```shell
-$ sq '@sakila_pg | .actor | where(.actor_id < 10) | .first_name | .[0:3]'
+$ sq '@sakila_pg | .actor | where(.actor_id < 10) | .first_name, .last_name | .[0:3]'
 first_name  last_name
 PENELOPE    GUINESS
 NICK        WAHLBERG


### PR DESCRIPTION
Minor typo, but was confused since some of the following docs reference this command showing the last name output