### PR TITLE
Switch install instructions to use core brew formula

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,11 +30,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -45,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -59,4 +59,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest,macos-latest]
+        os: [ubuntu-latest]
         node: [18.x]
 
     steps:

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -20,7 +20,7 @@ sq '@postgres_db | .actor | .first_name, .last_name | .[0:5]'
 ## Installation
 
 {{< tabs name="sq-install" >}}
-{{{< tab name="mac" codelang="shell" >}}brew install neilotoole/sq/sq{{< /tab >}}
+{{{< tab name="mac" codelang="shell" >}}brew install sq{{< /tab >}}
 {{< tab name="linux" codelang="shell" >}}/bin/sh -c "$(curl -fsSL https://sq.io/install.sh)"{{< /tab >}}}
 {{< tab name="win" codelang="shell">}}scoop bucket add sq https://github.com/neilotoole/sq
 scoop install sq{{< /tab >}}}

--- a/content/en/docs/install.md
+++ b/content/en/docs/install.md
@@ -60,8 +60,12 @@ Pre-built binaries are available from [GitHub releases](https://github.com/neilo
 ## macOS
 
 ```shell
-brew install neilotoole/sq/sq
+brew install sq
 ```
+
+{{< alert icon="👉" >}}
+`sq` is now a [core brew formula](https://formulae.brew.sh/formula/sq#default). Previously, `sq` was available via `brew install neilotoole/sq/sq`. If you have installed `sq` this way, you should uninstall it (`brew uninstall neilotoole/sq/sq`) before installing the new formula via `brew install sq`.
+{{< /alert >}}
 
 ## Windows
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   NODE_VERSION = "18"
   NPM_VERSION = "9.2.0"
-  HUGO_VERSION = "0.122.0"
+  HUGO_VERSION = "0.139.2"
 
 [context.production]
   command = "npm run build"


### PR DESCRIPTION
`sq` is now available as a [core brew formula](https://formulae.brew.sh/formula/sq#default) (i.e. use `brew install sq` instead of `brew install neilotoole/sq/sq`). Instructions updated to use core formula.