### PR TITLE
Chore/navbar menu size

### DIFF
--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -194,6 +194,7 @@ $font-size-xl:                $font-size-base * 1.375;
 $font-size-lg:                $font-size-base * 1.25;
 $font-size-md:                $font-size-base * 1.125;
 $font-size-sm:                $font-size-base * 0.775;
+$font-size-command:           $font-size-base * 0.9;
 
 // $line-height-base:            1.5;
 

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -188,6 +188,7 @@ $font-family-monospace:       sfmono-regular, menlo, monaco, consolas, "Liberati
 $font-family-base:            $font-family-sans-serif;
 // stylelint-enable value-keyword-case
 
+$font-size-command:           0.9rem;
 $font-size-base:              1rem; // Assumes the browser default, typically `16px`
 $font-size-xl:                $font-size-base * 1.375;
 $font-size-lg:                $font-size-base * 1.25;

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -188,7 +188,6 @@ $font-family-monospace:       sfmono-regular, menlo, monaco, consolas, "Liberati
 $font-family-base:            $font-family-sans-serif;
 // stylelint-enable value-keyword-case
 
-$font-size-command:           0.9rem;
 $font-size-base:              1rem; // Assumes the browser default, typically `16px`
 $font-size-xl:                $font-size-base * 1.375;
 $font-size-lg:                $font-size-base * 1.25;

--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -135,7 +135,7 @@ pre {
   align-items: center;
   padding: 0.25rem 0.5rem 0.25rem 0;
   font-weight: $headings-font-weight;
-  font-size: $font-size-base;
+  font-size: $font-size-command;
   text-transform: uppercase;
   color: $body-color;
   background-color: transparent;


### PR DESCRIPTION
Small style change to the COMMAND navbar items.

Before:

<img width="192" height="254" alt="image" src="https://github.com/user-attachments/assets/ccb07aa8-18b6-4421-b61e-0adb8f7ec618" />

After:

<img width="158" height="198" alt="image" src="https://github.com/user-attachments/assets/05f5e574-af4b-4146-a694-f66544ab888f" />

