### PR TITLE
Add a count of GH stars to the navbar

### DIFF
--- a/assets/js/gh-stars.js
+++ b/assets/js/gh-stars.js
@@ -1,0 +1,32 @@
+(function () {
+  function formatCount(n) {
+    if (n >= 1000) {
+      return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+    }
+    return String(n);
+  }
+
+  function run() {
+    var el = document.getElementById('gh-stars-count');
+    if (!el) return;
+    fetch('https://api.github.com/repos/neilotoole/sq', { method: 'GET', headers: { Accept: 'application/vnd.github.v3+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error(r.status)); })
+      .then(function (d) {
+        if (d && typeof d.stargazers_count === 'number') {
+          el.textContent = formatCount(d.stargazers_count);
+        }
+      })
+      .catch(function () { /* leave fallback ··· or clear */ });
+  }
+
+  function init() {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', run);
+    } else {
+      run();
+    }
+  }
+  if (typeof window !== 'undefined') {
+    init();
+  }
+})();

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -491,3 +491,20 @@ button#doks-versions {
     padding-left: 0.5rem;
   }
 }
+
+// GitHub stars: match navbar style (no badge bg), number + star icon
+.gh-stars-link {
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    color: inherit;
+    text-decoration: none;
+    opacity: 0.8;
+  }
+
+  .gh-stars-count {
+    font-size: 0.875rem;
+    font-variant-numeric: tabular-nums;
+  }
+}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,6 +1,7 @@
 {{- $dest := .Destination -}}
-{{- $isInternal := hasPrefix $dest "/" -}}
-{{- if $isInternal -}}
+{{- $isExternal := or (hasPrefix $dest "http://") (hasPrefix $dest "https://") (hasPrefix $dest "//") (hasPrefix $dest "mailto:") -}}
+{{- $isInternal := not $isExternal -}}
+{{- if and $isInternal (hasPrefix $dest "/") -}}
   {{- $dest = $dest | absURL -}}
 {{- end -}}
-<a href="{{ $dest | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if not $isInternal }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+<a href="{{ $dest | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isExternal }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -62,6 +62,8 @@
 {{ $scrollLock := resources.Get "js/scroll-lock.js" | js.Build -}}
 {{ $slice = $slice | append $scrollLock -}}
 
+{{ $ghStars := resources.Get "js/gh-stars.js" | js.Build -}}
+
 {{ if .Site.Params.options.toTopButton -}}
   {{ $toTopButton := resources.Get "js/to-top.js" -}}
   {{ $toTopButton := $toTopButton | js.Build -}}
@@ -82,6 +84,7 @@
     <script src="{{ $katexAutoRender.RelPermalink }}" onload="renderMathInElement(document.body);" defer></script>
   {{ end -}}
   <script src="{{ $js.RelPermalink }}" defer></script>
+  <script src="{{ $ghStars.RelPermalink }}" defer></script>
   {{ with .Params.mermaid -}}
     <script src="{{ $mermaid.RelPermalink }}" defer></script>
   {{ end -}}
@@ -103,6 +106,8 @@
     <script src="{{ $katexAutoRender.RelPermalink }}" integrity="{{ $katexAutoRender.Data.Integrity }}" crossorigin="anonymous" defer></script>
   {{ end -}}
   <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous" defer></script>
+  {{ $ghStars := $ghStars | minify | fingerprint "sha512" -}}
+  <script src="{{ $ghStars.RelPermalink }}" integrity="{{ $ghStars.Data.Integrity }}" crossorigin="anonymous" defer></script>
   {{ with .Params.mermaid -}}
     <script src="{{ $mermaid.RelPermalink }}" integrity="{{ $mermaid.Data.Integrity }}" crossorigin="anonymous" defer></script>
   {{ end -}}

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -95,10 +95,16 @@
 
 
         <hr class="text-black-50 my-4 d-lg-none">
-        <ul class="nav flex-column flex-lg-row">
+        <ul class="nav flex-column flex-lg-row align-items-center">
           {{ range .Site.Menus.social -}}
-            <li class="nav-item">
-              <a class="nav-link social-link" href="{{ .URL | relURL }}">{{ .Pre | safeHTML }}<small class="ms-2 d-lg-none">{{ .Name | safeHTML }}</small></a>
+            <li class="nav-item d-flex align-items-center">
+              <a class="nav-link social-link d-flex align-items-center" href="{{ .URL | relURL }}">{{ .Pre | safeHTML }}<small class="ms-2 d-lg-none">{{ .Name | safeHTML }}</small></a>
+              {{ if strings.HasPrefix (.URL | relURL) "https://github.com/neilotoole/sq" -}}
+                <a class="nav-link social-link gh-stars-link py-0 px-1 d-flex align-items-center gap-1" href="https://github.com/neilotoole/sq/stargazers" aria-label="GitHub stars for sq">
+                  <span id="gh-stars-count" class="gh-stars-count" aria-hidden="true">···</span>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-star" aria-hidden="true"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 6.84 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+                </a>
+              {{ end -}}
             </li>
           {{ end -}}
         </ul>

--- a/scripts/validate-build.sh
+++ b/scripts/validate-build.sh
@@ -158,7 +158,17 @@ else
     print_fail "Docs overview returned ${DOC_CODE}"
 fi
 
-# 6. No bad absolute links (localhost without port when we expect a port)
+# 6. Relative links must not have target="_blank" (render-link regression)
+print_test "Relative links open in same tab (no target=_blank on internal relative)"
+if [[ "$HOMEPAGE_OK" != true ]]; then
+    print_fail "Homepage did not respond; cannot check page content"
+elif echo "$BODY" | grep -qE 'target="_blank"[^>]*href="(\.\./|\./|[a-gi-zA-Z][a-zA-Z0-9]*/)|href="(\.\./|\./|[a-gi-zA-Z][a-zA-Z0-9]*/)[^>]*target="_blank"'; then
+    print_fail "Page has relative link(s) with target=_blank (should open in same tab)"
+else
+    print_pass "No relative links incorrectly set to open in new tab"
+fi
+
+# 7. No bad absolute links (localhost without port when we expect a port)
 print_test "No links to localhost without port (would break when clicked)"
 if [[ "$HOMEPAGE_OK" != true ]]; then
     print_fail "Homepage did not respond; cannot check page content"
@@ -168,7 +178,7 @@ else
     print_pass "No port-stripped localhost links"
 fi
 
-# 7. Follow key nav links (simulate click: resolve href and fetch)
+# 8. Follow key nav links (simulate click: resolve href and fetch)
 print_test "Following key links from homepage (simulate click)"
 KEY_PATHS=("/docs/overview/" "/docs/install/")
 LINK_FAIL=0
@@ -184,7 +194,7 @@ if [[ $LINK_FAIL -eq 0 ]]; then
     print_pass "Key links /docs/overview, /docs/install return 200"
 fi
 
-# 8. Nav links absolute with expected port when BASE_URL has a port (so click works)
+# 9. Nav links absolute with expected port when BASE_URL has a port (so click works)
 print_test "Nav links are absolute with port (so click works)"
 if [[ "$HOMEPAGE_OK" != true ]]; then
     print_fail "Homepage did not respond; cannot check page content"

--- a/scripts/validate-build.sh
+++ b/scripts/validate-build.sh
@@ -162,10 +162,15 @@ fi
 print_test "Relative links open in same tab (no target=_blank on internal relative)"
 if [[ "$HOMEPAGE_OK" != true ]]; then
     print_fail "Homepage did not respond; cannot check page content"
-elif echo "$BODY" | grep -qE 'target="_blank"[^>]*href="(\.\./|\./|[a-gi-zA-Z][a-zA-Z0-9]*/)|href="(\.\./|\./|[a-gi-zA-Z][a-zA-Z0-9]*/)[^>]*target="_blank"'; then
-    print_fail "Page has relative link(s) with target=_blank (should open in same tab)"
 else
-    print_pass "No relative links incorrectly set to open in new tab"
+    # Match lines with target="_blank" and relative-style href (../, ./, or word/). Use [a-zA-Z]
+    # so links like href="history/" are caught; exclude lines with href="http(s) (valid external).
+    REL_BAD=$(echo "$BODY" | grep -E 'target="_blank"[^>]*href="(\.\./|\./|[a-zA-Z][a-zA-Z0-9]*/)|href="(\.\./|\./|[a-zA-Z][a-zA-Z0-9]*/)[^>]*target="_blank"' | grep -v 'href="https\?://' || true)
+    if [[ -n "$REL_BAD" ]]; then
+        print_fail "Page has relative link(s) with target=_blank (should open in same tab)"
+    else
+        print_pass "No relative links incorrectly set to open in new tab"
+    fi
 fi
 
 # 7. No bad absolute links (localhost without port when we expect a port)


### PR DESCRIPTION
This PR adds a little addition to the navbar. Now the amount of GH stars for sq are show:

<img width="148" height="48" alt="Screenshot 2026-02-16 at 13 41 20" src="https://github.com/user-attachments/assets/f3738b0b-38a1-42c9-b5d3-53cb7ee47700" />
<img width="152" height="51" alt="Screenshot 2026-02-16 at 13 41 08" src="https://github.com/user-attachments/assets/3b598b2e-7286-49bc-8743-ca23f56d3fb3" />

# Testing

- Pull PR
- `make run`
- Open http://localhost:8080 and check the navbar