### PR TITLE
Add ClickHouse driver documentation

### DIFF
--- a/content/en/docs/concepts/index.md
+++ b/content/en/docs/concepts/index.md
@@ -35,7 +35,7 @@ Learn more in the [sources](/docs/source) section.
 ### Driver type
 
 This is the [driver](#driver) type used to connect to the source,
-e.g. `postgres`, `sqlserver`, `csv`, etc. You can specify the type explicitly
+e.g. `postgres`, `sqlserver`, `clickhouse`, `csv`, etc. You can specify the type explicitly
 when invoking [`sq add`](/docs/cmd/add), but usually `sq` can [detect](/docs/detect/#driver-type)
 the driver automatically.
 
@@ -176,6 +176,7 @@ but some drivers don't support the catalog mechanism. Here's a summary:
 | [SQLite](/docs/drivers/sqlite)        | `main`               | No                                                                                                            |
 | [MySQL](/docs/drivers/mysql)          | Connection-dependent | [No](https://dev.mysql.com/doc/connector-odbc/en/connector-odbc-usagenotes-functionality-catalog-schema.html) |
 | [SQL server](/docs/drivers/sqlserver) | `dbo`                | Yes                                                                                                           |
+| [ClickHouse](/docs/drivers/clickhouse) | `default`            | Yes                                                                                                           |
 
 The SLQ functions [`schema()`](/docs/query#schema) and [`catalog()`](/docs/query#catalog) return
 the schema and catalog of the active source. See the docs for details of how each driver implements

--- a/content/en/docs/drivers/clickhouse.md
+++ b/content/en/docs/drivers/clickhouse.md
@@ -92,41 +92,27 @@ Wrapper types such as `Nullable(T)` and `LowCardinality(T)` are unwrapped
 before mapping. For example, `LowCardinality(Nullable(String))` is treated
 as `String`, which maps to `kind.Text`.
 
-#### ClickHouse to sq (reading/querying)
-
-| ClickHouse Type                       | sq Kind         | Notes                              |
-|---------------------------------------|-----------------|------------------------------------|
-| `Int8`, `Int16`, `Int32`, `Int64`     | `kind.Int`      | All signed integers                |
-| `UInt8`, `UInt16`, `UInt32`, `UInt64` | `kind.Int`      | All unsigned integers              |
-| `Float32`, `Float64`                  | `kind.Float`    |                                    |
-| `Decimal(P,S)`, `Decimal128(S)`, etc. | `kind.Decimal`  | All Decimal variants               |
-| `Bool`                                | `kind.Bool`     |                                    |
-| `String`, `FixedString(N)`            | `kind.Text`     |                                    |
-| `UUID`                                | `kind.Text`     |                                    |
-| `Date`, `Date32`                      | `kind.Date`     |                                    |
-| `DateTime`, `DateTime64`              | `kind.Datetime` | Including parameterized variants   |
-| `Array(T)`                            | `kind.Text`     | Serialized as comma-separated text |
-| `Enum8(...)`, `Enum16(...)`           | `kind.Text`     |                                    |
-| `Map(K,V)`, `Tuple(...)`              | `kind.Text`     |                                    |
-
-#### sq to ClickHouse (writing/creating tables)
-
-| sq Kind         | ClickHouse Type | Notes                            |
-|-----------------|-----------------|----------------------------------|
-| `kind.Text`     | `String`        |                                  |
-| `kind.Int`      | `Int64`         |                                  |
-| `kind.Float`    | `Float64`       |                                  |
-| `kind.Decimal`  | `Decimal(18,4)` |                                  |
-| `kind.Bool`     | `Bool`          |                                  |
-| `kind.Date`     | `Date`          |                                  |
-| `kind.Datetime` | `DateTime`      |                                  |
-| `kind.Time`     | `DateTime`      | ClickHouse has no time-only type |
-| `kind.Bytes`    | `String`        | Binary data stored as String     |
+| ClickHouse Type (read)                | sq Kind         | ClickHouse Type (write) | Notes                              |
+|---------------------------------------|-----------------|-------------------------|------------------------------------|
+| `Int8`, `Int16`, `Int32`, `Int64`     | `kind.Int`      | `Int64`                 | All signed integers                |
+| `UInt8`, `UInt16`, `UInt32`, `UInt64` | `kind.Int`      | `Int64`                 | All unsigned integers              |
+| `Float32`, `Float64`                  | `kind.Float`    | `Float64`               |                                    |
+| `Decimal(P,S)`, `Decimal128(S)`, etc. | `kind.Decimal`  | `Decimal(18,4)`         | All Decimal variants               |
+| `Bool`                                | `kind.Bool`     | `Bool`                  |                                    |
+| `String`, `FixedString(N)`            | `kind.Text`     | `String`                |                                    |
+| `UUID`                                | `kind.Text`     | `String`                |                                    |
+| `Date`, `Date32`                      | `kind.Date`     | `Date`                  |                                    |
+| `DateTime`, `DateTime64`              | `kind.Datetime` | `DateTime`              | Including parameterized variants   |
+| `Array(T)`                            | `kind.Text`     | `String`                | Serialized as comma-separated text |
+| `Enum8(...)`, `Enum16(...)`           | `kind.Text`     | `String`                |                                    |
+| `Map(K,V)`, `Tuple(...)`              | `kind.Text`     | `String`                |                                    |
+| —                                     | `kind.Time`     | `DateTime`              | ClickHouse has no time-only type   |
+| —                                     | `kind.Bytes`    | `String`                | Binary data stored as String       |
 
 Nullable columns are wrapped with `Nullable(T)` (e.g., `Nullable(String)`,
 `Nullable(Int64)`). ClickHouse columns are non-nullable by default.
 
-Note that the mapping is not a perfect round-trip. For example, `Int8` and `Int64`
+The mapping is not a perfect round-trip. For example, `Int8` and `Int64`
 both become `kind.Int`, and `kind.Int` always maps back to `Int64`. Similarly,
 `kind.Time` maps to `DateTime`, which reads back as `kind.Datetime`, and
 `kind.Bytes` maps to `String`, which reads back as `kind.Text`.

--- a/content/en/docs/drivers/clickhouse.md
+++ b/content/en/docs/drivers/clickhouse.md
@@ -1,0 +1,147 @@
+---
+title: "ClickHouse"
+description: "ClickHouse"
+draft: false
+images: []
+weight: 4035
+toc: true
+url: /docs/drivers/clickhouse
+---
+The `sq` ClickHouse driver implements connectivity for
+[ClickHouse](https://clickhouse.com), an open-source columnar database focused on
+real-time analytics. The driver requires ClickHouse v25+.
+The driver implements all optional driver features.
+
+{{< alert icon="🐥" >}}
+The ClickHouse driver is in beta release. There is still work to be done with
+testing and edge cases. It is likely that the implementation will change
+based upon user feedback. If you find a bug, please open an
+[issue](https://github.com/neilotoole/sq/issues/new/choose).
+{{< /alert >}}
+
+## Add source
+
+Use [`sq add`](/docs/cmd/add) to add a source. The location argument should
+start with `clickhouse://`. For example:
+
+```shell
+sq add 'clickhouse://default:@localhost:9000/default'
+```
+
+With authentication:
+
+```shell
+sq add 'clickhouse://user:password@host:9000/database' --handle @ch
+```
+
+## Connection string format
+
+```text
+clickhouse://username:password@hostname:9000/database
+clickhouse://username:password@hostname:9000/database?param=value
+```
+
+Default ports:
+
+| Protocol | Non-Secure | Secure (TLS) |
+|----------|------------|--------------|
+| Native   | `9000`     | `9440`       |
+
+If the port is omitted, `sq` auto-applies the default port: `9000` for
+non-secure connections, or `9440` when `secure=true` is specified.
+
+## Notes
+
+### Active schema & catalog
+
+ClickHouse "database" maps to `sq`'s [schema and catalog](/docs/concepts/#schema--catalog) concepts.
+
+When executing a `sq` query, you can use `--src.schema` to specify the active schema
+(or _catalog.schema_).
+
+```shell
+sq --src.schema=system '.tables | .[0:3]'
+```
+
+### Table engine
+
+When `sq` creates tables (e.g., via `--insert` or `tbl copy`), it uses the
+[MergeTree](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree)
+engine with `ORDER BY` on the first column. MergeTree is the standard
+ClickHouse table engine for most workloads.
+
+### Mutations
+
+ClickHouse does not support standard SQL `UPDATE` syntax directly. Instead,
+it uses `ALTER TABLE ... UPDATE` for mutations. `sq` handles this transparently:
+you can use `sq` normally and the driver generates the correct ClickHouse-specific
+SQL. Mutations are forced to execute synchronously (via `mutations_sync = 1`)
+so that data is consistent immediately after the operation returns.
+
+### Rows affected
+
+ClickHouse does not report the number of rows affected by DML operations
+(`INSERT`, `UPDATE`, `DELETE`). When using `sq` with ClickHouse, you'll see
+`rows affected: unsupported` in text output, or `-1` in JSON/YAML/etc output.
+
+### Type mapping
+
+ClickHouse's type system is richer than `sq`'s
+[kind system](/docs/concepts), so some type coarsening occurs.
+Wrapper types such as `Nullable(T)` and `LowCardinality(T)` are unwrapped
+before mapping. For example, `LowCardinality(Nullable(String))` is treated
+as `String`, which maps to `kind.Text`.
+
+#### ClickHouse to sq (reading/querying)
+
+| ClickHouse Type                       | sq Kind         | Notes                              |
+|---------------------------------------|-----------------|------------------------------------|
+| `Int8`, `Int16`, `Int32`, `Int64`     | `kind.Int`      | All signed integers                |
+| `UInt8`, `UInt16`, `UInt32`, `UInt64` | `kind.Int`      | All unsigned integers              |
+| `Float32`, `Float64`                  | `kind.Float`    |                                    |
+| `Decimal(P,S)`, `Decimal128(S)`, etc. | `kind.Decimal`  | All Decimal variants               |
+| `Bool`                                | `kind.Bool`     |                                    |
+| `String`, `FixedString(N)`            | `kind.Text`     |                                    |
+| `UUID`                                | `kind.Text`     |                                    |
+| `Date`, `Date32`                      | `kind.Date`     |                                    |
+| `DateTime`, `DateTime64`              | `kind.Datetime` | Including parameterized variants   |
+| `Array(T)`                            | `kind.Text`     | Serialized as comma-separated text |
+| `Enum8(...)`, `Enum16(...)`           | `kind.Text`     |                                    |
+| `Map(K,V)`, `Tuple(...)`              | `kind.Text`     |                                    |
+
+#### sq to ClickHouse (writing/creating tables)
+
+| sq Kind         | ClickHouse Type | Notes                            |
+|-----------------|-----------------|----------------------------------|
+| `kind.Text`     | `String`        |                                  |
+| `kind.Int`      | `Int64`         |                                  |
+| `kind.Float`    | `Float64`       |                                  |
+| `kind.Decimal`  | `Decimal(18,4)` |                                  |
+| `kind.Bool`     | `Bool`          |                                  |
+| `kind.Date`     | `Date`          |                                  |
+| `kind.Datetime` | `DateTime`      |                                  |
+| `kind.Time`     | `DateTime`      | ClickHouse has no time-only type |
+| `kind.Bytes`    | `String`        | Binary data stored as String     |
+
+Nullable columns are wrapped with `Nullable(T)` (e.g., `Nullable(String)`,
+`Nullable(Int64)`). ClickHouse columns are non-nullable by default.
+
+Note that the mapping is not a perfect round-trip. For example, `Int8` and `Int64`
+both become `kind.Int`, and `kind.Int` always maps back to `Int64`. Similarly,
+`kind.Time` maps to `DateTime`, which reads back as `kind.Datetime`, and
+`kind.Bytes` maps to `String`, which reads back as `kind.Text`.
+See [#544](https://github.com/neilotoole/sq/issues/544).
+
+#### Array types
+
+`Array(T)` types (e.g., `Array(String)`, `Array(Int32)`) are serialized as
+comma-separated text values. For example, `["Action", "Drama"]` becomes
+`Action,Drama` as `kind.Text`. This means that the original array structure
+cannot be reconstructed from the text representation.
+See [#545](https://github.com/neilotoole/sq/issues/545).
+
+## Related
+
+- [ClickHouse driver README](https://github.com/neilotoole/sq/blob/master/drivers/clickhouse/README.md)
+- [#544](https://github.com/neilotoole/sq/issues/544) — Type roundtrip issues (`kind.Time`, `kind.Bytes`)
+- [#545](https://github.com/neilotoole/sq/issues/545) — Array types flattened to CSV text (information loss)

--- a/content/en/docs/overview.md
+++ b/content/en/docs/overview.md
@@ -12,7 +12,7 @@ url: /docs/overview
 `sq` is the missing tool for wrangling data. A swiss-army knife for data.
 
 `sq` provides a [jq](https://jqlang.github.io/jq/)-style syntax to query, join, migrate, and export data from a variety of data sources,
-such as Postgres, SQLite, SQL Server, MySQL, Excel or CSV, with the ability to fall back
+such as Postgres, SQLite, SQL Server, MySQL, ClickHouse, Excel or CSV, with the ability to fall back
 to actual SQL for trickier work. In essence, `sq` treats every data source as if it were a SQL database.
 `sq` also provides several handy commands such as `inspect`, `ping`, or `tbl copy`.
 
@@ -22,7 +22,7 @@ to actual SQL for trickier work. In essence, `sq` treats every data source as if
 - A *source* is a specific data source such as a database instance, or Excel or CSV file etc. Each source
   has a:
   - `driver`: such as [`postgres`](/docs/drivers/postgres), [`sqlserver`](/docs/drivers/sqlserver),
-    [`csv`](/docs/drivers/csv), or [`xlsx`](/docs/drivers/xlsx).
+    [`clickhouse`](/docs/drivers/clickhouse), [`csv`](/docs/drivers/csv), or [`xlsx`](/docs/drivers/xlsx).
   - `location`: URI or filepath of the source, such as `postgres://sakila:****@localhost/sakila` or `/Users/neilotoole/sq/xl_demo.xlsx`.
   - `handle`: this is how `sq` refers to that particular _source_, e.g. `@sakila_pg`, `@prod/customer` or `@xl_demo`. The handle must begin with `@`.
 - [Active Source](/docs/concepts/#active-source) is the default source upon which `sq` acts if no other source is specified.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -32,6 +32,7 @@
           <li><a href="/docs/drivers/sqlite">SQLite</a></li>
           <li><a href="/docs/drivers/mysql">MySQL, MariaDB</a></li>
           <li><a href="/docs/drivers/sqlserver">SQL Server, Azure SQL Edge</a></li>
+          <li><a href="/docs/drivers/clickhouse">ClickHouse</a></li>
         </ul>
       </div>
       <div class="col-lg-5">


### PR DESCRIPTION
## Summary

- Add new driver documentation page at `/docs/drivers/clickhouse` covering connection setup, ClickHouse-specific behavior (mutations, rows affected, table engine), and a combined roundtrip type mapping table
- Add ClickHouse to the landing page SQL Sources list, overview page, and concepts page (driver type examples and catalog/schema support table)

## Files changed

| File | Change |
|------|--------|
| `content/en/docs/drivers/clickhouse.md` | New driver page |
| `layouts/index.html` | Add ClickHouse to SQL Sources list |
| `content/en/docs/overview.md` | Add ClickHouse to database and driver lists |
| `content/en/docs/concepts/index.md` | Add ClickHouse to driver type examples and catalog/schema table |

## Test plan

- [ ] Verify `/docs/drivers/clickhouse` renders correctly on deploy preview
- [ ] Verify ClickHouse appears in sidebar under Drivers
- [ ] Verify landing page, overview, and concepts pages reference ClickHouse
- [ ] Verify all internal links resolve
- [ ] Markdown linting passes